### PR TITLE
Little fix in communication engine and 4 new API commands

### DIFF
--- a/engine_communicator.py
+++ b/engine_communicator.py
@@ -1,23 +1,30 @@
 from websocket import create_connection
-import jwt
+from jwt import JWT, jwk_from_pem
 import ssl
-
+import os
+from datetime import datetime, timedelta
 
 class EngineCommunicator:
 
-    def __init__(self, url):
+    def __init__(self, url, debug=False):
         self.url = url
         self.ws = create_connection(self.url)
         self.session = self.ws.recv()  # Holds session object. Required for Qlik Sense Sept. 2017 and later
+        if debug:
+            print ("> " + self.session)
        
     @staticmethod
     def send_call(self, call_msg):
+        if debug:
+            print ("> " + call_msg)
         self.ws.send(call_msg)
 
         # Qlik sometimes returns more than one json response for a single request -- perhaps should use an async socket.
         # Might be needed to append all responses to returned data in a future review
         while True:
             data = self.ws.recv()
+            if debug:
+                print("< " + data)
             if ('result' in data or 'error' in data):
                 break
         return data
@@ -28,14 +35,25 @@ class EngineCommunicator:
 
 class SecureEngineCommunicator(EngineCommunicator):
 
-    def __init__(self, senseHost, proxyPrefix, userDirectory, userId, privateKeyPath, ignoreCertErrors=False):
+    def __init__(self, senseHost, proxyPrefix, userDirectory, userId, privateKeyPath, userGroup=None, ignoreCertErrors=False, rootCA=None, ):
         self.url = "wss://" + senseHost + "/" + proxyPrefix + "/app/engineData"
         sslOpts = {}
         if ignoreCertErrors:
             sslOpts = {"cert_reqs": ssl.CERT_NONE}
+        else:
+            if rootCA is not None:
+                sslOpts = {'ca_certs': rootCA}
+            else:
+                sslOpts = None
         
-        privateKey = open(privateKeyPath).read()
-        token = jwt.encode({'user': userId, 'directory': userDirectory}, privateKey, algorithm='RS256')
+        payload = {'user': userId, 'directory': userDirectory}
+        if userGroup is not None:
+            payload['group'] = userGroup
 
-        self.ws = create_connection(self.url, sslopt=sslOpts, header=['Authorization: BEARER ' + str(token)])
+        privateKey = jwk_from_pem(open(privateKeyPath,"rb").read())
+        token=JWT().encode(key=privateKey, alg='RS256',
+                           payload=payload,
+                           optional_headers={'exp': (datetime.utcnow() + timedelta(minutes=10)).isoformat()} )
+               
+        self.ws = create_connection(self.url, sslopt=sslOpts, header=['authorization: bearer ' + str(token)])
         self.session = self.ws.recv()

--- a/engine_communicator.py
+++ b/engine_communicator.py
@@ -13,7 +13,13 @@ class EngineCommunicator:
     @staticmethod
     def send_call(self, call_msg):
         self.ws.send(call_msg)
-        return self.ws.recv()
+
+        # Qlik sometimes returns more than one json response for a sinclu request -- perhaps should use an async socker?
+        while True:
+            data = self.ws.recv()
+            if ('result' in data or 'error' in data):
+                break
+        return data
 
     @staticmethod
     def close_qvengine_connection(self):

--- a/engine_communicator.py
+++ b/engine_communicator.py
@@ -14,7 +14,8 @@ class EngineCommunicator:
     def send_call(self, call_msg):
         self.ws.send(call_msg)
 
-        # Qlik sometimes returns more than one json response for a sinclu request -- perhaps should use an async socker?
+        # Qlik sometimes returns more than one json response for a single request -- perhaps should use an async socket.
+        # Might be needed to append all responses to returned data in a future review
         while True:
             data = self.ws.recv()
             if ('result' in data or 'error' in data):

--- a/engine_field_api.py
+++ b/engine_field_api.py
@@ -6,6 +6,17 @@ class EngineFieldApi:
     def __init__(self, socket):
         self.engine_socket = socket
 
+    def select_match(self, fld_handle, value=None):
+        if value is None:
+            value = []
+        msg = json.dumps({"jsonrpc": "2.0", "id": 0, "handle": fld_handle, "method": "Select",
+                          "params": [value, False]})
+        response = json.loads(self.engine_socket.send_call(self.engine_socket, msg))
+        try:
+            return response
+        except KeyError:
+            return response["error"]
+
     def select_values(self, fld_handle, values=None):
         if values is None:
             values = []

--- a/engine_generic_object_api.py
+++ b/engine_generic_object_api.py
@@ -22,8 +22,17 @@ class EngineGenericObjectApi:
         except KeyError:
             return response["error"]
 
-     def get_hypercube_data(self, handle, path="/qHyperCubeDef", pages=[]):
+    def get_hypercube_data(self, handle, path="/qHyperCubeDef", pages=[]):
         msg = json.dumps({"jsonrpc": "2.0", "id": 0, "handle": handle, "method": "GetHyperCubeData",
+                          "params": [path,pages]})
+        response = json.loads(self.engine_socket.send_call(self.engine_socket, msg))
+        try:
+            return response["result"]
+        except KeyError:
+            return response["error"]
+
+    def get_hypercube_pivot_data(self, handle, path="/qHyperCubeDef", pages=[]):
+        msg = json.dumps({"jsonrpc": "2.0", "id": 0, "handle": handle, "method": "GetHyperCubePivotData",
                           "params": [path,pages]})
         response = json.loads(self.engine_socket.send_call(self.engine_socket, msg))
         try:

--- a/engine_generic_object_api.py
+++ b/engine_generic_object_api.py
@@ -14,7 +14,15 @@ class EngineGenericObjectApi:
         except KeyError:
             return response["error"]
 
-    def get_hypercube_data(self, handle, path="/qHyperCubeDef", pages=[]):
+    def get_properties(self, handle):
+        msg = json.dumps({"jsonrpc": "2.0", "id": 0, "handle": handle, "method": "GetProperties", "params": []})
+        response = json.loads(self.engine_socket.send_call(self.engine_socket, msg))
+        try:
+            return response["result"]
+        except KeyError:
+            return response["error"]
+
+     def get_hypercube_data(self, handle, path="/qHyperCubeDef", pages=[]):
         msg = json.dumps({"jsonrpc": "2.0", "id": 0, "handle": handle, "method": "GetHyperCubeData",
                           "params": [path,pages]})
         response = json.loads(self.engine_socket.send_call(self.engine_socket, msg))

--- a/engine_generic_object_api.py
+++ b/engine_generic_object_api.py
@@ -48,3 +48,12 @@ class EngineGenericObjectApi:
             return response["result"]
         except KeyError:
             return response["error"]
+
+    def expand_left(self, handle, path="/qHyperCubeDef", row=0, col=0, all=True):
+        msg = json.dumps({"jsonrpc": "2.0", "id": 0, "handle": handle, "method": "ExpandLeft",
+                          "params": [path, row, col, all]})
+        response = json.loads(self.engine_socket.send_call(self.engine_socket, msg))
+        try:
+            return response["result"]
+        except KeyError:
+            return response["error"]

--- a/pyqlikengine.py
+++ b/pyqlikengine.py
@@ -4,11 +4,11 @@ import engine_app_api, engine_communicator, engine_field_api, engine_generic_obj
 class QixEngine:
 
     def __init__(self, url, is_secure=False, proxy_prefix='', user_directory='', user_id='', private_key_path='',
-                 ignore_cert_errors=False):
+                 ignore_cert_errors=False, root_ca=None):
         self.url = url
         if is_secure:
             self.conn = engine_communicator.SecureEngineCommunicator(url, proxy_prefix, user_directory,user_id,
-                                                                    private_key_path, ignore_cert_errors)
+                                                                    private_key_path, ignore_cert_errors, root_ca)
         else:
             self.conn = engine_communicator.EngineCommunicator(url)
         self.ega = engine_global_api.EngineGlobalApi(self.conn)

--- a/pyqlikengine.py
+++ b/pyqlikengine.py
@@ -4,13 +4,14 @@ import engine_app_api, engine_communicator, engine_field_api, engine_generic_obj
 class QixEngine:
 
     def __init__(self, url, is_secure=False, proxy_prefix='', user_directory='', user_id='', private_key_path='',
-                 ignore_cert_errors=False, root_ca=None):
+                 ignore_cert_errors=False, root_ca=None, debug=None):
         self.url = url
         if is_secure:
-            self.conn = engine_communicator.SecureEngineCommunicator(url, proxy_prefix, user_directory,user_id,
-                                                                    private_key_path, ignore_cert_errors, root_ca)
+            self.conn = engine_communicator.SecureEngineCommunicator(senseHost=url, proxyPrefix=proxy_prefix, userDirectory=user_directory,
+                                                                     userId=user_id, privateKeyPath=private_key_path, ignoreCertErrors=ignore_cert_errors, 
+                                                                     rootCA=root_ca, debug=debug)
         else:
-            self.conn = engine_communicator.EngineCommunicator(url)
+            self.conn = engine_communicator.EngineCommunicator(url, debug=debug)
         self.ega = engine_global_api.EngineGlobalApi(self.conn)
         self.eaa = engine_app_api.EngineAppApi(self.conn)
         self.egoa = engine_generic_object_api.EngineGenericObjectApi(self.conn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-websocket
+wsaccel
+websocket-client
 jwt
 pandas
+pprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+websocket
+jwt
+pandas


### PR DESCRIPTION
Had some issues when qlik returned more than one response to the connection/authentication frames. Added a quick fix for this situation.

Added 4 API commands:
SelectMatch - to Field API;
GetProperties - to Generic Object API;
GetHypercubePivotData - to Generica Object API;
ExtendLeft - to Generic Object API.